### PR TITLE
Add personId (person_id) to available options

### DIFF
--- a/src/stringifyDates.js
+++ b/src/stringifyDates.js
@@ -9,5 +9,9 @@ module.exports = options => {
 		qs.end_date = toDateString(options.endDate);
 	}
 
+	if (options.personId) {
+		qs.person_id = options.personId;
+	}
+
 	return qs;
 };

--- a/src/stringifyDates.test.js
+++ b/src/stringifyDates.test.js
@@ -25,4 +25,12 @@ describe('stringifyDates', () => {
 
 		expect(Object.keys(output).length).toBe(1);
 	});
+
+	it('adds the person id', () => {
+		const output = stringifyDates({ personId: 1234 });
+
+		expect(output).toMatchObject({
+			person_id: 1234,
+		});
+	});
 });


### PR DESCRIPTION
Adds `personId` as available option. It will be converted to `person_id` as query parameter in the API URL. 

Person ID can be used e.g. in the `assignments` API to filter assignments by person.